### PR TITLE
Add account calls to match bclient

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -711,6 +711,38 @@ class MultisigWallet extends EventEmitter {
   }
 
   /**
+   * Get wallet accounts.
+   * Note: Multisig wallets only have 1 `default` account currently.
+   * @returns {Array}
+   */
+
+  getAccounts() {
+    return ['default'];
+  }
+
+  /**
+   * Get wallet account.
+   * @param {String} account
+   * @returns {Promise}
+   */
+
+  async getAccount(account) {
+    assert(account === 'default',
+      'Only default account available for multisig wallets');
+    const info = await this.client.getInfo(this.id, true);
+    return info.account;
+  }
+
+  /**
+   * Create account (unavailable for multisig wallets)
+   * @returns {Error}
+   */
+
+  createAccount() {
+    throw new Error('Can\'t create accounts on multisig wallet');
+  }
+
+  /**
    * Create address.
    * @returns {Promise}
    */
@@ -751,7 +783,7 @@ class MultisigWallet extends EventEmitter {
    * @returns {Promise}
    */
 
-  resendWallet() {
+  resend() {
     return this.client.resendWallet(this.id);
   }
 


### PR DESCRIPTION
Adds account calls to match `bclient` wallet interface.

More generally, to simplify client implementations, bmultisig-client interface should extend existing bclient wallet functionality. If functions are not available for multisig wallets it should throw an error on those calls. This way clients can implement against the same API (with the exception of added functionality such as proposals).

This would probably be easier if `MultisigWallet` could extend bclients' `Wallet`, but this isn't currently exposed in `module.exports`. This would make maintenance easier going forward by de-duping code. This will need to be changed in `bclient` so that this object is exposed and extendable: https://github.com/bcoin-org/bclient/blob/master/lib/wallet.js#L610