### PR TITLE
Make MultisigWallet more compatible to WalletClient

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -8,77 +8,20 @@
 'use strict';
 
 const assert = require('bsert');
-const {enforce} = assert;
 const EventEmitter = require('events');
 const {WalletClient} = require('bclient');
-const {URL} = require('url');
-
-const MULTISIG_PREFIX = '/multisig';
 
 /**
  * Multisig wallet client
  * @extends {bcoin#WalletClient}
- * @property {String} [rootPath=/] - path for wallet
- * @property {String} [multisigPath=/multisig] - path for multisig wallet
  */
 class MultisigClient extends WalletClient {
   /**
    * Create multisig client.
    * @param {Object} options - Wallet Client options
-   * @param {String} [path=/] - path for wallet
-   * @param {String} [multisigPath=/multisig] - path for multisig wallet
    */
   constructor(options) {
     super(options);
-
-    this.rootPath = this.path;
-    this.multisigPath = this.path + MULTISIG_PREFIX;
-    this.path = this.multisigPath;
-
-    if (options)
-      this.fromOptions(options);
-  }
-
-  /**
-   * Inject options.
-   * @param {Object} options
-   * @returns {MultisigClient}
-   */
-
-  fromOptions(options) {
-    assert(options, 'Options are required.');
-
-    if (options.multisigPath != null) {
-      enforce(typeof options.multisigPath === 'string',
-        'multisigPath', 'string');
-
-      this.multisigPath = options.multisigPath;
-      this.path = options.multisigPath;
-    }
-
-    if (options.multisigPath != null && options.path == null) {
-      // tidy up little bit for URL parser.
-      const up = this.multisigPath.slice(-1) === '/' ? '../' : '/../';
-      const url = new URL(options.multisigPath + up, this.getBaseURL());
-
-      assert(url.host === this.host,
-        `Could not get root path for multisig path ${options.multisigPath}`
-      );
-
-      this.rootPath = url.pathname.slice(0, -1);
-    }
-  }
-
-  /**
-   * Get base url. (helper)
-   * @private
-   * @returns {String}
-   */
-
-  getBaseURL() {
-    const protocol = this.ssl ? 'https:' : 'http:';
-
-    return `${protocol}//${this.host}/`;
   }
 
   /**
@@ -126,22 +69,6 @@ class MultisigClient extends WalletClient {
   }
 
   /**
-   * Send request to bwallet endpoitns.
-   * @param {String} method
-   * @param {String} endpoint
-   * @param {Object} params
-   */
-
-  requestRoot(method, endpoint, params) {
-    try {
-      this.path = this.rootPath;
-      return this.request(method, endpoint, params);
-    } finally {
-      this.path = this.multisigPath;
-    }
-  }
-
-  /**
    * Create a multisig wallet object
    * @param {String} id
    * @param {String|Buffer} token
@@ -153,41 +80,12 @@ class MultisigClient extends WalletClient {
   }
 
   /**
-   * Rescan the chain (Admin only).
-   * @param {Number} height
-   * @returns {Promise}
-   */
-
-  rescan(height) {
-    return this.requestRoot('POST', '/rescan', { height });
-  }
-
-  /**
-   * Resend pending transactions (Admin only).
-   * @returns {Promise}
-   */
-
-  resend() {
-    return this.requestRoot('POST', '/resend');
-  }
-
-  /**
-   * Backup the walletdb (Admin only).
-   * @param {String} path
-   * @returns {Promise}
-   */
-
-  backup(path) {
-    return this.requestRoot('POST', '/backup', { path });
-  }
-
-  /**
    * Get wallets (Admin only).
    * @returns {Promise<String[]>} list of wallets
    */
 
   async getWallets() {
-    const wallets = await this.get('/');
+    const wallets = await this.get('/multisig');
 
     // returns null when not configured properly
     if (!wallets)
@@ -204,7 +102,7 @@ class MultisigClient extends WalletClient {
    */
 
   createWallet(id, options) {
-    return this.put(`/${id}`, options);
+    return this.put(`/multisig/${id}`, options);
   }
 
   /**
@@ -214,7 +112,7 @@ class MultisigClient extends WalletClient {
    */
 
   async removeWallet(id) {
-    const removed = await this.del(`/${id}`);
+    const removed = await this.del(`/multisig/${id}`);
 
     if (!removed)
       return false;
@@ -230,7 +128,7 @@ class MultisigClient extends WalletClient {
    */
 
   joinWallet(id, cosignerOptions) {
-    return this.post(`/${id}/join`, cosignerOptions);
+    return this.post(`/multisig/${id}/join`, cosignerOptions);
   }
 
   /**
@@ -239,8 +137,10 @@ class MultisigClient extends WalletClient {
    * @returns {Promise}
    */
 
-  getHistory(id) {
-    return this.get(`/${id}/tx/history`);
+  getHistory(id, account) {
+    assert(account === 'default',
+      'Only default account available for multisig wallets.');
+    return this.get(`/multisig/${id}/tx/history`);
   }
 
   /**
@@ -249,8 +149,10 @@ class MultisigClient extends WalletClient {
    * @returns {Promise<Coin[]>}
    */
 
-  getCoins(id) {
-    return this.get(`/${id}/coin`);
+  getCoins(id, account) {
+    assert(account === 'default',
+      'Only default account available for multisig wallets.');
+    return this.get(`/multisig/${id}/coin`);
   }
 
   /**
@@ -259,8 +161,10 @@ class MultisigClient extends WalletClient {
    * @returns {Promise}
    */
 
-  getPending(id) {
-    return this.get(`${id}/tx/unconfirmed`);
+  getPending(id, account) {
+    assert(account === 'default',
+      'Only default account available for multisig wallets.');
+    return this.get(`/multisig/${id}/tx/unconfirmed`);
   }
 
   /**
@@ -269,19 +173,24 @@ class MultisigClient extends WalletClient {
    * @returns {Promise<bcoin#Balance>}
    */
 
-  getBalance(id) {
-    return this.get(`/${id}/balance`);
+  getBalance(id, account) {
+    assert(account === 'default',
+      'Only default account available for multisig wallets.');
+    return this.get(`/multisig/${id}/balance`);
   }
 
   /**
    * Get last N wallet transactions.
    * @param {String} id
+   * @param {String} account
    * @param {Number} limit - Max number of transactions.
    * @returns {Promise}
    */
 
-  getLast(id, limit) {
-    return this.get(`/${id}/tx/last`, { limit });
+  getLast(id, account, limit) {
+    assert(account === 'default',
+      'Only default account available for multisig wallets.');
+    return this.get(`/multisig/${id}/tx/last`, { limit });
   }
 
   /**
@@ -295,8 +204,11 @@ class MultisigClient extends WalletClient {
    * @returns {Promise}
    */
 
-  getRange(id, options) {
-    return this.get(`/${id}/tx/range`, {
+  getRange(id, account, options) {
+    assert(account === 'default',
+      'Only default account available for multisig wallets.');
+
+    return this.get(`/multisig/${id}/tx/range`, {
       start: options.start,
       end: options.end,
       limit: options.limit,
@@ -313,7 +225,7 @@ class MultisigClient extends WalletClient {
    */
 
   getTX(id, hash) {
-    return this.get(`/${id}/tx/${hash}`);
+    return this.get(`/multisig/${id}/tx/${hash}`);
   }
 
   /**
@@ -324,7 +236,7 @@ class MultisigClient extends WalletClient {
    */
 
   getBlocks(id) {
-    return this.get(`/${id}/block`);
+    return this.get(`/multisig/${id}/block`);
   }
 
   /**
@@ -335,7 +247,7 @@ class MultisigClient extends WalletClient {
    */
 
   getBlock(id, height) {
-    return this.get(`/${id}/block/${height}`);
+    return this.get(`/multisig/${id}/block/${height}`);
   }
 
   /**
@@ -348,7 +260,7 @@ class MultisigClient extends WalletClient {
    */
 
   getCoin(id, hash, index) {
-    return this.get(`/${id}/coin/${hash}/${index}`);
+    return this.get(`/multisig/${id}/coin/${hash}/${index}`);
   }
 
   /**
@@ -357,8 +269,44 @@ class MultisigClient extends WalletClient {
    * @returns {Promise}
    */
 
-  zap(id, age) {
-    return this.post(`/${id}/zap`, { age });
+  zap(id, account, age) {
+    assert(account === 'default',
+      'Only default account available for multisig wallets.');
+
+    return this.post(`/multisig/${id}/zap`, { age });
+  }
+
+  /**
+   * Create wallet transaction
+   * @param {String} id
+   * @param {Object} options - transaction options
+   * @returns {Promise<TX>}
+   */
+
+  createTX(id, options) {
+    return this.post(`/multisig/${id}/create`, options);
+  }
+
+  /**
+   * Create a transaction, fill, sign, and broadcast.
+   * @param {Object} options
+   * @param {String} options.address
+   * @param {Amount} options.value
+   * @returns {Promise}
+   */
+
+  send(id, options) {
+    throw new Error('Cant use method "send" on multisig wallet.');
+  }
+
+  /**
+   * Sign a transaction.
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  sign(id, options) {
+    throw new Error('Cant use method "sign" on multisig wallet.');
   }
 
   /**
@@ -369,7 +317,50 @@ class MultisigClient extends WalletClient {
    */
 
   getInfo(id, details) {
-    return this.get(`/${id}`, { details });
+    return this.get(`/multisig/${id}`, { details });
+  }
+
+  /**
+   * Get wallet accounts.
+   * @returns {Promise} - Returns Array.
+   */
+
+  async getAccounts(id) {
+    return ['default'];
+  }
+
+  /**
+   * Get wallet master key.
+   * @returns {Promise}
+   */
+
+  getMaster(id) {
+    throw new Error('Cant use method "getMaster" on multisig wallet.');
+  }
+
+  /**
+   * Get wallet account.
+   * @param {String} account
+   * @returns {Promise}
+   */
+
+  async getAccount(id, account) {
+    assert(account === 'default',
+      'Only default account available for multisig wallets.');
+    const info = await this.getInfo(id, true);
+
+    return info.account;
+  }
+
+  /**
+   * Create account.
+   * @param {String} name
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createAccount(id, name, options) {
+    throw new Error('Cant use method "createAccount" on multisig wallet.');
   }
 
   /**
@@ -378,8 +369,10 @@ class MultisigClient extends WalletClient {
    * @returns {Promise}
    */
 
-  createAddress(id) {
-    return this.post(`/${id}/address`);
+  createAddress(id, account) {
+    assert(account === 'default',
+      'Only default account available for multisig wallets.');
+    return this.post(`/multisig/${id}/address`);
   }
 
   /**
@@ -388,8 +381,10 @@ class MultisigClient extends WalletClient {
    * @returns {Promise}
    */
 
-  createChange(id) {
-    return this.post(`/${id}/change`);
+  createChange(id, account) {
+    assert(account === 'default',
+      'Only default account available for multisig wallets.');
+    return this.post(`/multisig/${id}/change`);
   }
 
   /**
@@ -398,8 +393,10 @@ class MultisigClient extends WalletClient {
    * @returns {Promise}
    */
 
-  createNested(id) {
-    return this.post(`/${id}/nested`);
+  createNested(id, account) {
+    assert(account === 'default',
+      'Only default account available for multisig wallets.');
+    return this.post(`/multisig/${id}/nested`);
   }
 
   /**
@@ -409,7 +406,91 @@ class MultisigClient extends WalletClient {
    */
 
   retoken(id) {
-    return this.post(`/${id}/retoken`);
+    return this.post(`/multisig/${id}/retoken`);
+  }
+
+  /**
+   * Import private key.
+   * @param {Number|String} account
+   * @param {String} key
+   * @returns {Promise}
+   */
+
+  importPrivate(id, account, privateKey, passphrase) {
+    throw new Error('Cant use method "importPrivate" on multisig wallet.');
+  }
+
+  /**
+   * Import public key.
+   * @param {Number|String} account
+   * @param {String} key
+   * @returns {Promise}
+   */
+
+  importPublic(id, account, publicKey) {
+    throw new Error('Cant use method "importPublic" on multisig wallet.');
+  }
+
+  /**
+   * Import address.
+   * @param {Number|String} account
+   * @param {String} address
+   * @returns {Promise}
+   */
+
+  importAddress(id, account, address) {
+    throw new Error('Cant use method "importAddress" on multisig wallet.');
+  }
+
+  /**
+   * Lock a coin.
+   * @param {String} hash
+   * @param {Number} index
+   * @returns {Promise}
+   */
+
+  lockCoin(id, hash, index) {
+    throw new Error('Cant use method "lockCoin" on multisig wallet.');
+  }
+
+  /**
+   * Unlock a coin.
+   * @param {String} hash
+   * @param {Number} index
+   * @returns {Promise}
+   */
+
+  unlockCoin(id, hash, index) {
+    throw new Error('Cant use method "unlockCoin" on multisig wallet.');
+  }
+
+  /**
+   * Get locked coins.
+   * @returns {Promise}
+   */
+
+  getLocked(id) {
+    throw new Error('Cant use method "getLocked" on multisig wallet.');
+  }
+
+  /**
+   * Lock wallet.
+   * @returns {Promise}
+   */
+
+  lock(id) {
+    throw new Error('Cant use method "lock" on multisig wallet.');
+  }
+
+  /**
+   * Unlock wallet.
+   * @param {String} passphrase
+   * @param {Number} timeout
+   * @returns {Promise}
+   */
+
+  unlock(id, passphrase, timeout) {
+    throw new Error('Cant use method "unlock" on multisig wallet.');
   }
 
   /**
@@ -420,7 +501,40 @@ class MultisigClient extends WalletClient {
    */
 
   getKey(id, address) {
-    return this.get(`/${id}/key/${address}`);
+    return this.get(`/multisig/${id}/key/${address}`);
+  }
+
+  /**
+   * Get wallet key WIF dump.
+   * @param {String} address
+   * @param {String?} passphrase
+   * @returns {Promise}
+   */
+
+  getWIF(id, address, passphrase) {
+    throw new Error('Cant use method "getWIF" on multisig wallet.');
+  }
+
+  /**
+   * Add a public account key to the wallet for multisig.
+   * @param {String} account
+   * @param {String} key - Account (bip44) key (base58).
+   * @returns {Promise}
+   */
+
+  addSharedKey(id, account, accountKey) {
+    throw new Error('Cant use method "addSharedKey" on multisig wallet.');
+  }
+
+  /**
+   * Remove a public account key to the wallet for multisig.
+   * @param {String} account
+   * @param {String} key - Account (bip44) key (base58).
+   * @returns {Promise}
+   */
+
+  removeSharedKey(id, account, accountKey) {
+    throw new Error('Cant use method "removeSharedKey" on multisig wallet.');
   }
 
   /**
@@ -430,33 +544,12 @@ class MultisigClient extends WalletClient {
    */
 
   resendWallet(id) {
-    return this.post(`/${id}/resend`);
-  }
-
-  /**
-   * Get wallet key.
-   * @param {String} id
-   * @param {String} address
-   * @returns {Promise}
-   */
-  getKey(id, address) {
-    return this.get(`/${id}/key/${address}`);
+    return this.post(`/multisig/${id}/resend`);
   }
 
   /*
    * Proposals
    */
-
-  /**
-   * Create wallet transaction
-   * @param {String} id
-   * @param {Object} options - transaction options
-   * @returns {Promise<TX>}
-   */
-
-  createTX(id, options) {
-    return this.post(`/${id}/create`, options);
-  }
 
   /**
    * Get proposals
@@ -466,7 +559,9 @@ class MultisigClient extends WalletClient {
    */
 
   async getProposals(id, pending = true) {
-    const proposalsObject = await this.get(`/${id}/proposal`, { pending });
+    const proposalsObject = await this.get(`/multisig/${id}/proposal`, {
+      pending
+    });
 
     return proposalsObject.proposals;
   }
@@ -479,7 +574,7 @@ class MultisigClient extends WalletClient {
    */
 
   createProposal(id, options) {
-    return this.post(`/${id}/proposal`, options);
+    return this.post(`/multisig/${id}/proposal`, options);
   }
 
   /**
@@ -490,7 +585,7 @@ class MultisigClient extends WalletClient {
    */
 
   getProposalInfo(id, pid) {
-    return this.get(`/${id}/proposal/${pid}`);
+    return this.get(`/multisig/${id}/proposal/${pid}`);
   }
 
   /**
@@ -505,7 +600,7 @@ class MultisigClient extends WalletClient {
    */
 
   getProposalMTX(id, pid, options) {
-    return this.get(`/${id}/proposal/${pid}/tx`, options);
+    return this.get(`/multisig/${id}/proposal/${pid}/tx`, options);
   }
 
   /**
@@ -518,7 +613,7 @@ class MultisigClient extends WalletClient {
    */
 
   approveProposal(id, pid, signatures, broadcast) {
-    return this.post(`/${id}/proposal/${pid}/approve`, {
+    return this.post(`/multisig/${id}/proposal/${pid}/approve`, {
       signatures,
       broadcast
     });
@@ -532,7 +627,7 @@ class MultisigClient extends WalletClient {
    */
 
   rejectProposal(id, pid) {
-    return this.post(`/${id}/proposal/${pid}/reject`);
+    return this.post(`/multisig/${id}/proposal/${pid}/reject`);
   }
 
   /**
@@ -543,7 +638,7 @@ class MultisigClient extends WalletClient {
    */
 
   sendProposal(id, pid) {
-    return this.post(`/${id}/proposal/${pid}/send`);
+    return this.post(`/multisig/${id}/proposal/${pid}/send`);
   }
 }
 
@@ -613,8 +708,8 @@ class MultisigWallet extends EventEmitter {
    * @returns {Promise}
    */
 
-  getHistory() {
-    return this.client.getHistory(this.id);
+  getHistory(account) {
+    return this.client.getHistory(this.id, account);
   }
 
   /**
@@ -622,8 +717,8 @@ class MultisigWallet extends EventEmitter {
    * @returns {Promise<Coin[]>}
    */
 
-  getCoins() {
-    return this.client.getCoins(this.id);
+  getCoins(account) {
+    return this.client.getCoins(this.id, account);
   }
 
   /**
@@ -631,8 +726,8 @@ class MultisigWallet extends EventEmitter {
    * @returns {Promise}
    */
 
-  getPending() {
-    return this.client.getPending(this.id);
+  getPending(account) {
+    return this.client.getPending(this.id, account);
   }
 
   /**
@@ -640,8 +735,8 @@ class MultisigWallet extends EventEmitter {
    * @returns {Promise<bcoin#Balance>}
    */
 
-  getBalance() {
-    return this.client.getBalance(this.id);
+  getBalance(account) {
+    return this.client.getBalance(this.id, account);
   }
 
   /**
@@ -650,8 +745,8 @@ class MultisigWallet extends EventEmitter {
    * @returns {Promise}
    */
 
-  getLast(limit) {
-    return this.client.getLast(this.id, limit);
+  getLast(account, limit) {
+    return this.client.getLast(this.id, account, limit);
   }
 
   /**
@@ -664,8 +759,8 @@ class MultisigWallet extends EventEmitter {
    * @returns {Promise}
    */
 
-  getRange(options) {
-    return this.client.getRange(this.id, options);
+  getRange(account, options) {
+    return this.client.getRange(this.id, account, options);
   }
 
   /**
@@ -717,8 +812,40 @@ class MultisigWallet extends EventEmitter {
    * @returns {Promise}
    */
 
-  zap(age) {
-    return this.client.zap(this.id, age);
+  zap(account, age) {
+    return this.client.zap(this.id, account, age);
+  }
+
+  /**
+   * Create wallet transaction
+   * @param {Object} options - transaction options
+   * @returns {Promise<TX>}
+   */
+
+  createTX(options) {
+    return this.client.createTX(this.id, options);
+  }
+
+  /**
+   * Create a transaction, fill, sign, and broadcast.
+   * @param {Object} options
+   * @param {String} options.address
+   * @param {Amount} options.value
+   * @returns {Promise}
+   */
+
+  send(options) {
+    return this.client.send(this.id, options);
+  }
+
+  /**
+   * Sign a transaction.
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  sign(options) {
+    return this.client.sign(this.id, options);
   }
 
   /**
@@ -732,12 +859,51 @@ class MultisigWallet extends EventEmitter {
   }
 
   /**
+   * Get wallet accounts.
+   * @returns {Promise} - Returns Array.
+   */
+
+  getAccounts() {
+    return this.client.getAccounts(this.id);
+  }
+
+  /**
+   * Get wallet master key.
+   * @returns {Promise}
+   */
+
+  getMaster() {
+    return this.client.getMaster(this.id);
+  }
+
+  /**
+   * Get wallet account.
+   * @param {String} account
+   * @returns {Promise}
+   */
+
+  getAccount(account) {
+    return this.client.getAccount(this.id, account);
+  }
+
+  /**
+   * Create account.
+   * @param {String} name
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createAccount(name, options) {
+    return this.client.createAccount(this.id, name, options);
+  }
+
+  /**
    * Create address.
    * @returns {Promise}
    */
 
-  createAddress() {
-    return this.client.createAddress(this.id);
+  createAddress(account) {
+    return this.client.createAddress(this.id, account);
   }
 
   /**
@@ -745,8 +911,8 @@ class MultisigWallet extends EventEmitter {
    * @returns {Promise}
    */
 
-  createChange() {
-    return this.client.createChange(this.id);
+  createChange(account) {
+    return this.client.createChange(this.id, account);
   }
 
   /**
@@ -754,18 +920,19 @@ class MultisigWallet extends EventEmitter {
    * @returns {Promise}
    */
 
-  createNested() {
-    return this.client.createNested(this.id);
+  createNested(account) {
+    return this.client.createNested(this.id, account);
   }
 
   /**
-   * Get wallet key.
-   * @param {String} address
+   * Change or set master key`s passphrase.
+   * @param {String|Buffer} passphrase
+   * @param {(String|Buffer)?} old
    * @returns {Promise}
    */
 
-  getKey(address) {
-    return this.client.getKey(this.id, address);
+  setPassphrase(passphrase, old) {
+    return this.client.setPassphrase(this.id, passphrase, old);
   }
 
   /**
@@ -778,12 +945,87 @@ class MultisigWallet extends EventEmitter {
   }
 
   /**
-   * Resend wallet transactions.
+   * Import private key.
+   * @param {Number|String} account
+   * @param {String} key
    * @returns {Promise}
    */
 
-  resendWallet() {
-    return this.client.resendWallet(this.id);
+  importPrivate(account, privateKey, passphrase) {
+    return this.client.importPrivate(this.id, account, privateKey, passphrase);
+  }
+
+  /**
+   * Import public key.
+   * @param {Number|String} account
+   * @param {String} key
+   * @returns {Promise}
+   */
+
+  importPublic(account, publicKey) {
+    return this.client.importPublic(this.id, account, publicKey);
+  }
+
+  /**
+   * Import address.
+   * @param {Number|String} account
+   * @param {String} address
+   * @returns {Promise}
+   */
+
+  importAddress(account, address) {
+    return this.client.importAddress(this.id, account, address);
+  }
+
+  /**
+   * Lock a coin.
+   * @param {String} hash
+   * @param {Number} index
+   * @returns {Promise}
+   */
+
+  lockCoin(hash, index) {
+    return this.client.lockCoin(this.id, hash, index);
+  }
+
+  /**
+   * Unlock a coin.
+   * @param {String} hash
+   * @param {Number} index
+   * @returns {Promise}
+   */
+
+  unlockCoin(hash, index) {
+    return this.client.unlockCoin(this.id, hash, index);
+  }
+
+  /**
+   * Get locked coins.
+   * @returns {Promise}
+   */
+
+  getLocked() {
+    return this.client.getLocked(this.id);
+  }
+
+  /**
+   * Lock wallet.
+   * @returns {Promise}
+   */
+
+  lock() {
+    return this.client.lock(this.id);
+  }
+
+  /**
+   * Unlock wallet.
+   * @param {String} passphrase
+   * @param {Number} timeout
+   * @returns {Promise}
+   */
+
+  unlock(passphrase, timeout) {
+    return this.client.unlock(this.id, passphrase, timeout);
   }
 
   /**
@@ -791,23 +1033,56 @@ class MultisigWallet extends EventEmitter {
    * @param {String} address
    * @returns {Promise}
    */
+
   getKey(address) {
     return this.client.getKey(this.id, address);
+  }
+
+  /**
+   * Get wallet key WIF dump.
+   * @param {String} address
+   * @param {String?} passphrase
+   * @returns {Promise}
+   */
+
+  getWIF(address, passphrase) {
+    return this.client.getWIF(this.id, address, passphrase);
+  }
+
+  /**
+   * Add a public account key to the wallet for multisig.
+   * @param {String} account
+   * @param {String} key - Account (bip44) key (base58).
+   * @returns {Promise}
+   */
+
+  addSharedKey(account, accountKey) {
+    return this.client.addSharedKey(this.id, account, accountKey);
+  }
+
+  /**
+   * Remove a public account key to the wallet for multisig.
+   * @param {String} account
+   * @param {String} key - Account (bip44) key (base58).
+   * @returns {Promise}
+   */
+
+  removeSharedKey(account, accountKey) {
+    return this.client.removeSharedKey(this.id, account, accountKey);
+  }
+
+  /**
+   * Resend wallet transactions.
+   * @returns {Promise}
+   */
+
+  resend() {
+    return this.client.resendWallet(this.id);
   }
 
   /*
    * Proposals
    */
-
-  /**
-   * Create wallet transaction
-   * @param {Object} options - transaction options
-   * @returns {Promise<TX>}
-   */
-
-  createTX(options) {
-    return this.client.createTX(this.id, options);
-  }
 
   /**
    * Get proposals

--- a/lib/client.js
+++ b/lib/client.js
@@ -413,6 +413,17 @@ class MultisigClient extends WalletClient {
   }
 
   /**
+   * Get wallet key.
+   * @param {String} id
+   * @param {String} address
+   * @returns {Promise}
+   */
+
+  getKey(id, address) {
+    return this.get(`/${id}/key/${address}`);
+  }
+
+  /**
    * Resend wallet transactions.
    * @param {String} id
    * @returns {Promise}
@@ -745,6 +756,16 @@ class MultisigWallet extends EventEmitter {
 
   createNested() {
     return this.client.createNested(this.id);
+  }
+
+  /**
+   * Get wallet key.
+   * @param {String} address
+   * @returns {Promise}
+   */
+
+  getKey(address) {
+    return this.client.getKey(this.id, address);
   }
 
   /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -137,7 +137,7 @@ class MultisigClient extends WalletClient {
    * @returns {Promise}
    */
 
-  getHistory(id, account) {
+  getHistory(id, account = 'default') {
     assert(account === 'default',
       'Only default account available for multisig wallets.');
     return this.get(`/multisig/${id}/tx/history`);
@@ -149,7 +149,7 @@ class MultisigClient extends WalletClient {
    * @returns {Promise<Coin[]>}
    */
 
-  getCoins(id, account) {
+  getCoins(id, account = 'default') {
     assert(account === 'default',
       'Only default account available for multisig wallets.');
     return this.get(`/multisig/${id}/coin`);
@@ -161,7 +161,7 @@ class MultisigClient extends WalletClient {
    * @returns {Promise}
    */
 
-  getPending(id, account) {
+  getPending(id, account = 'default') {
     assert(account === 'default',
       'Only default account available for multisig wallets.');
     return this.get(`/multisig/${id}/tx/unconfirmed`);
@@ -173,7 +173,7 @@ class MultisigClient extends WalletClient {
    * @returns {Promise<bcoin#Balance>}
    */
 
-  getBalance(id, account) {
+  getBalance(id, account = 'default') {
     assert(account === 'default',
       'Only default account available for multisig wallets.');
     return this.get(`/multisig/${id}/balance`);
@@ -187,7 +187,7 @@ class MultisigClient extends WalletClient {
    * @returns {Promise}
    */
 
-  getLast(id, account, limit) {
+  getLast(id, account = 'default', limit) {
     assert(account === 'default',
       'Only default account available for multisig wallets.');
     return this.get(`/multisig/${id}/tx/last`, { limit });
@@ -204,7 +204,7 @@ class MultisigClient extends WalletClient {
    * @returns {Promise}
    */
 
-  getRange(id, account, options) {
+  getRange(id, account = 'default', options) {
     assert(account === 'default',
       'Only default account available for multisig wallets.');
 
@@ -269,7 +269,7 @@ class MultisigClient extends WalletClient {
    * @returns {Promise}
    */
 
-  zap(id, account, age) {
+  zap(id, account = 'default', age) {
     assert(account === 'default',
       'Only default account available for multisig wallets.');
 
@@ -344,7 +344,7 @@ class MultisigClient extends WalletClient {
    * @returns {Promise}
    */
 
-  async getAccount(id, account) {
+  async getAccount(id, account = 'default') {
     assert(account === 'default',
       'Only default account available for multisig wallets.');
     const info = await this.getInfo(id, true);
@@ -369,7 +369,7 @@ class MultisigClient extends WalletClient {
    * @returns {Promise}
    */
 
-  createAddress(id, account) {
+  createAddress(id, account = 'default') {
     assert(account === 'default',
       'Only default account available for multisig wallets.');
     return this.post(`/multisig/${id}/address`);
@@ -381,7 +381,7 @@ class MultisigClient extends WalletClient {
    * @returns {Promise}
    */
 
-  createChange(id, account) {
+  createChange(id, account = 'default') {
     assert(account === 'default',
       'Only default account available for multisig wallets.');
     return this.post(`/multisig/${id}/change`);
@@ -393,7 +393,7 @@ class MultisigClient extends WalletClient {
    * @returns {Promise}
    */
 
-  createNested(id, account) {
+  createNested(id, account = 'default') {
     assert(account === 'default',
       'Only default account available for multisig wallets.');
     return this.post(`/multisig/${id}/nested`);
@@ -639,6 +639,18 @@ class MultisigClient extends WalletClient {
 
   sendProposal(id, pid) {
     return this.post(`/multisig/${id}/proposal/${pid}/send`);
+  }
+
+  /**
+   * Set a new token.
+   * @param {String} id
+   * @param {Object} options
+   * @param {String} options.cosignerToken - hex string
+   * @returns {Promise}
+   */
+
+  setToken(id, options) {
+    return this.put(`/multisig/${id}/token`, options);
   }
 }
 
@@ -1158,6 +1170,16 @@ class MultisigWallet extends EventEmitter {
 
   sendProposal(pid) {
     return this.client.sendProposal(this.id, pid);
+  }
+
+  /**
+   * Set a new token.
+   * @param {Object} options
+   * @returns {Promise<Cosigner>}
+   */
+
+  setToken(options) {
+    return this.client.setToken(this.id, options);
   }
 }
 


### PR DESCRIPTION
- Add all non supported methods and throw error.
- Add account parameter back to methods but assert its default
- Make account param "default" by default.

This PR includes both of these:
https://github.com/bcoin-org/bmultisig-client/pull/1 and https://github.com/bcoin-org/bmultisig-client/pull/3