### PR TITLE
bugfix: stop property reference on null

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -565,6 +565,9 @@ class MultisigClient extends WalletClient {
       pending
     });
 
+    if (!proposalsObject)
+      return proposalsObject;
+
     return proposalsObject.proposals;
   }
 


### PR DESCRIPTION
`proposalsObject` can be `null` and this prevents a property reference on `null`